### PR TITLE
Update of Paho MQTT library and version bump (issue #3)

### DIFF
--- a/com.ibm.streamsx.mqtt/.classpath
+++ b/com.ibm.streamsx.mqtt/.classpath
@@ -3,6 +3,6 @@
 	<classpathentry kind="src" output="impl/java/bin" path="impl/java/src"/>
 	<classpathentry exported="true" kind="con" path="com.ibm.streams.java/com.ibm.streams.operator"/>
 	<classpathentry exported="true" kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
-	<classpathentry kind="lib" path="opt/downloaded/org.eclipse.paho.client.mqttv3-1.0.1.jar"/>
+	<classpathentry kind="lib" path="opt/downloaded/org.eclipse.paho.client.mqttv3-1.2.1.jar"/>
 	<classpathentry kind="output" path="impl/java/bin"/>
 </classpath>

--- a/com.ibm.streamsx.mqtt/info.xml
+++ b/com.ibm.streamsx.mqtt/info.xml
@@ -136,7 +136,7 @@ The &lt;MQTT> element has the following attributes:
     If the truststore does not contain a public certificate for an MQTT server, the connection to that server is terminated.
 
 </info:description>
-    <info:version>1.0.1</info:version>
+    <info:version>1.0.2</info:version>
     <info:requiredProductVersion>4.2.0.0</info:requiredProductVersion>
   </info:identity>
   <info:dependencies/>

--- a/com.ibm.streamsx.mqtt/pom.xml
+++ b/com.ibm.streamsx.mqtt/pom.xml
@@ -6,7 +6,7 @@
     <groupId>com.ibm.streamsx.mqtt</groupId>
     <artifactId>streamsx.mqtt</artifactId>
     <packaging>jar</packaging>
-    <version>1.0.0</version>
+    <version>1.0.2</version>
     <name>com.ibm.streamsx.mqtt</name>
     <repositories>
         <repository>
@@ -20,7 +20,7 @@
         <dependency>
             <groupId>org.eclipse.paho</groupId>
             <artifactId>org.eclipse.paho.client.mqttv3</artifactId>
-            <version>1.0.1</version>
+            <version>1.2.1</version>
         </dependency>
     </dependencies>
     <build>


### PR DESCRIPTION
- Update to latest snapshot version (v1.2.1) of Paho MQTT library,
because of a reportet vulnerability.